### PR TITLE
👌 IMPROVE: Move Prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
 	},
 	"dependencies": {
 		"chalk": "^2.4.2",
-		"clear-any-console": "^1.16.0",
+		"clear-any-console": "^1.16.0"
+	},
+	"devDependencies": {
 		"prettier": "^2.0.5"
 	}
 }


### PR DESCRIPTION
Related to #1

Moves Prettier from production dependencies to development dependencies in `package.json`.

- Removes `prettier` from the `dependencies` section.
- Adds `prettier` to the `devDependencies` section, aligning with the best practice of categorizing packages that are only needed during development.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ahmadawais/cli-welcome/issues/1?shareId=b16c0f16-a9f9-4788-b337-6fa2d08071f1).